### PR TITLE
Add provides to resource

### DIFF
--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -18,7 +18,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource_name 'yum_mysql_community_repo'
+resource_name :yum_mysql_community_repo
+provides :yum_mysql_community_repo
 
 description 'Configure yum repo for MySQL Community edition' if respond_to?(:description)
 


### PR DESCRIPTION
Adds `provides :yum_mysql_community_repo` to the repo resource as per [CHEF-31](https://docs.chef.io/deprecations_resource_name_without_provides/) to support Chef 16. Looks like cookstyle didn't catch it because `resource_name` was a string instead of a symbol.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>