### PR TITLE
Insure dnf module is only disabled where required

### DIFF
--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -55,7 +55,7 @@ action :create do
   description 'Create MySQL Community Repo file'
 
   execute 'dnf -y module disable mysql' do
-    only_if { node['platform_version'].to_i >= 8 }
+    only_if { node['platform_version'].to_i >= 8 && platform_family?('rhel') }
     not_if 'dnf module list mysql | grep -q "^mysql.*\[x\]"'
   end
 


### PR DESCRIPTION
Restricts disabling the `mysql` dnf module to just RHEL distros. This was causing install failures on fedora systems.

(related to my work updating the MySQL cookbook to MySQL 8 + resources)

## Check List

- [x] All tests pass. See TESTING.md for details.
