### PR TITLE
Use dnf_module resource from yum cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Use `dnf_module` resource from `yum` cookbook instead of manually shelling out
+
 ## 5.0.2 - *2021-08-31*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Cookbooks
 
-- none
+- `yum` 7.2.0+ (for `dnf_module` resource)
 
 ## Attributes
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,14 +1,15 @@
+---
 driver:
   name: dokken
-  privileged: true  # because Docker and SystemD
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
-  env: [CHEF_LICENSE=accept]
+  privileged: true  # because Docker and systemd
 
 transport:
   name: dokken
 
 provisioner:
   name: dokken
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_license: accept-no-persist
 
 verifier:
   name: inspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,8 +3,11 @@ driver:
 
 provisioner:
   name: chef_zero
-  enforce_idempotency: true
+  product_name: chef
+  chef_license: accept-no-persist
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
   multiple_converge: 2
+  enforce_idempotency: true
   deprecations_as_errors: true
 
 verifier:

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,8 @@ source_url        'https://github.com/sous-chefs/yum-mysql-community'
 issues_url        'https://github.com/sous-chefs/yum-mysql-community/issues'
 chef_version      '>= 15.3'
 
+depends 'yum', '>= 7.2.0'
+
 supports 'amazon'
 supports 'centos'
 supports 'fedora'

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -55,9 +55,9 @@ property :mysql_cluster_community, [true, false],
 action :create do
   description 'Create MySQL Community Repo file'
 
-  execute 'dnf -y module disable mysql' do
-    only_if { node['platform_version'].to_i >= 8 && platform_family?('rhel') }
-    not_if 'dnf module list mysql | grep -q "^mysql.*\[x\]"'
+  dnf_module 'mysql' do
+    action :disable
+    only_if { node['platform_version'].to_i >= 8 }
   end
 
   template '/etc/yum.repos.d/mysql-community.repo' do


### PR DESCRIPTION
# Description

The `yum` cookbook now has a `dnf_module` resource for managing module streams, so use that instead of manually shelling out to disable the `mysql` module.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
