### PR TITLE
Update repo gpgkey url (attributes) mysql57, mysql-connectors; Also repo resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Update gpgkey urls in attribute:
+   - mysql57
+   - mysql-connectors
+- Update gpgkey url in repo resource
+
 ## 5.2.0 - *2022-01-08*
 
 - Switch to using yum_repository resource instead of template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Update gpgkey urls in attribute:
-   - mysql57
-   - mysql-connectors
-- Update gpgkey url in repo resource
+- Update gpgkey urls in attribute files: mysql57, mysql-connectors
+- Update gpgkey urls in repo resource
 
 ## 5.2.0 - *2022-01-08*
 

--- a/attributes/mysql-connectors-community.rb
+++ b/attributes/mysql-connectors-community.rb
@@ -1,5 +1,5 @@
 default['yum']['mysql-connectors-community']['repositoryid'] = 'mysql-connectors-community'
-default['yum']['mysql-connectors-community']['gpgkey'] = 'https://repo.mysql.com/RPM-GPG-KEY-mysql'
+default['yum']['mysql-connectors-community']['gpgkey'] = 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
 default['yum']['mysql-connectors-community']['description'] = 'MySQL Connectors Community'
 default['yum']['mysql-connectors-community']['gpgcheck'] = true
 default['yum']['mysql-connectors-community']['enabled'] = true

--- a/attributes/mysql57-community.rb
+++ b/attributes/mysql57-community.rb
@@ -1,5 +1,5 @@
 default['yum']['mysql57-community']['repositoryid'] = 'mysql57-community'
-default['yum']['mysql57-community']['gpgkey'] = 'https://repo.mysql.com/RPM-GPG-KEY-mysql'
+default['yum']['mysql57-community']['gpgkey'] = 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
 default['yum']['mysql57-community']['description'] = 'MySQL 5.7 Community Server'
 default['yum']['mysql57-community']['failovermethod'] = 'priority'
 default['yum']['mysql57-community']['gpgcheck'] = true

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -65,7 +65,7 @@ action :create do
     baseurl "https://repo.mysql.com/yum/mysql-#{new_resource.version}-community/#{os}/#{os_ver}/$basearch/"
     gpgcheck new_resource.gpgcheck
     enabled new_resource.mysql_community_server
-    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql'
+    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
   end
 
   yum_repository 'mysql-connectors-community' do
@@ -73,7 +73,7 @@ action :create do
     baseurl "https://repo.mysql.com/yum/mysql-connectors-community/#{os}/#{os_ver}/$basearch/"
     gpgcheck new_resource.gpgcheck
     enabled new_resource.mysql_connectors_community
-    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql'
+    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
   end
 
   yum_repository 'mysql-tools-community' do
@@ -81,7 +81,7 @@ action :create do
     baseurl "https://repo.mysql.com/yum/mysql-tools-community/#{os}/#{os_ver}/$basearch/"
     gpgcheck new_resource.gpgcheck
     enabled new_resource.mysql_tools_community
-    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql'
+    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
   end
 
   yum_repository 'mysql-tools-preview' do
@@ -89,7 +89,7 @@ action :create do
     baseurl "https://repo.mysql.com/yum/mysql-tools-preview/#{os}/#{os_ver}/$basearch/"
     gpgcheck new_resource.gpgcheck
     enabled new_resource.mysql_tools_preview
-    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql'
+    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
   end
 
   yum_repository 'mysql-cluster-community' do
@@ -97,7 +97,7 @@ action :create do
     baseurl "https://repo.mysql.com/yum/mysql-cluster-#{new_resource.version}-community/#{os}/#{os_ver}/$basearch/"
     gpgcheck new_resource.gpgcheck
     enabled new_resource.mysql_cluster_community
-    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql'
+    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
   end
 end
 


### PR DESCRIPTION
New 2022 gpgkey

No change to mysql55 or mysql56

```
kitchen list amazon
Instance                         Driver   Provisioner  Verifier  Transport  Last Action  Last Error
resource-amazonlinux2-current    Vagrant  ChefInfra    Inspec    Ssh        Verified     <None>
connectors-amazonlinux2-current  Vagrant  ChefInfra    Inspec    Ssh        Verified     <None>
mysql55-amazonlinux2-current     Vagrant  ChefInfra    Inspec    Ssh        Verified     <None>
mysql56-amazonlinux2-current     Vagrant  ChefInfra    Inspec    Ssh        Verified     <None>
mysql57-amazonlinux2-current     Vagrant  ChefInfra    Inspec    Ssh        Verified     <None>
```

Signed-off-by: Wade Peacock <knightorc@xqqme.com>