### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,9 +1,9 @@
 [local_phases]
-unit = "rspec spec/"
+unit = 'rspec spec/'
 lint = 'cookstyle --display-cop-names --extra-details'
-syntax = "echo skipping"
-provision = "echo skipping"
-deploy = "echo skipping"
-smoke = "echo skipping"
-functional = "echo skipping"
-cleanup = "echo skipping"
+syntax = 'echo skipping'
+provision = 'echo skipping'
+deploy = 'echo skipping'
+smoke = 'echo skipping'
+functional = 'echo skipping'
+cleanup = 'echo skipping'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- resolved cookstyle error: .delivery/project.toml:2:8 convention: `Style/StringLiterals`
+- resolved cookstyle error: .delivery/project.toml:4:10 convention: `Style/StringLiterals`
+- resolved cookstyle error: .delivery/project.toml:5:13 convention: `Style/StringLiterals`
+- resolved cookstyle error: .delivery/project.toml:6:10 convention: `Style/StringLiterals`
+- resolved cookstyle error: .delivery/project.toml:7:9 convention: `Style/StringLiterals`
+- resolved cookstyle error: .delivery/project.toml:8:14 convention: `Style/StringLiterals`
+- resolved cookstyle error: .delivery/project.toml:9:11 convention: `Style/StringLiterals`
 ## 5.3.1 - *2022-01-27*
 
 - Add Alma Linux and Rocky Linux to testing


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.32.0 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with .delivery/project.toml

 - 2:8 convention: `Style/StringLiterals` - Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://rubystyle.guide#consistent-string-literals)
 - 4:10 convention: `Style/StringLiterals` - Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://rubystyle.guide#consistent-string-literals)
 - 5:13 convention: `Style/StringLiterals` - Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://rubystyle.guide#consistent-string-literals)
 - 6:10 convention: `Style/StringLiterals` - Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://rubystyle.guide#consistent-string-literals)
 - 7:9 convention: `Style/StringLiterals` - Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://rubystyle.guide#consistent-string-literals)
 - 8:14 convention: `Style/StringLiterals` - Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://rubystyle.guide#consistent-string-literals)
 - 9:11 convention: `Style/StringLiterals` - Prefer single-quoted strings when you don't need string interpolation or special symbols. (https://rubystyle.guide#consistent-string-literals)