### PR TITLE
allow gpgkey to be configured and use 2023 key by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add gpgkey property to repo resource
+- Default to 2023 GPG key
+
 ## 5.3.4 - *2023-03-01*
 
 - Remove CircleCI

--- a/attributes/mysql-connectors-community.rb
+++ b/attributes/mysql-connectors-community.rb
@@ -1,5 +1,5 @@
 default['yum']['mysql-connectors-community']['repositoryid'] = 'mysql-connectors-community'
-default['yum']['mysql-connectors-community']['gpgkey'] = 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
+default['yum']['mysql-connectors-community']['gpgkey'] = 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2023'
 default['yum']['mysql-connectors-community']['description'] = 'MySQL Connectors Community'
 default['yum']['mysql-connectors-community']['gpgcheck'] = true
 default['yum']['mysql-connectors-community']['enabled'] = true

--- a/attributes/mysql57-community.rb
+++ b/attributes/mysql57-community.rb
@@ -1,5 +1,5 @@
 default['yum']['mysql57-community']['repositoryid'] = 'mysql57-community'
-default['yum']['mysql57-community']['gpgkey'] = 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2023'
+default['yum']['mysql57-community']['gpgkey'] = 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
 default['yum']['mysql57-community']['description'] = 'MySQL 5.7 Community Server'
 default['yum']['mysql57-community']['failovermethod'] = 'priority'
 default['yum']['mysql57-community']['gpgcheck'] = true

--- a/attributes/mysql57-community.rb
+++ b/attributes/mysql57-community.rb
@@ -1,5 +1,5 @@
 default['yum']['mysql57-community']['repositoryid'] = 'mysql57-community'
-default['yum']['mysql57-community']['gpgkey'] = 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
+default['yum']['mysql57-community']['gpgkey'] = 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2023'
 default['yum']['mysql57-community']['description'] = 'MySQL 5.7 Community Server'
 default['yum']['mysql57-community']['failovermethod'] = 'priority'
 default['yum']['mysql57-community']['gpgcheck'] = true

--- a/resources/repo.rb
+++ b/resources/repo.rb
@@ -32,6 +32,10 @@ property :gpgcheck, [true, false],
          default: true,
          description: 'Enable or disable GPG checks'
 
+property :gpgkey, [String, Array],
+         default: 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2023',
+         description: 'GPG key(s)'
+
 property :mysql_community_server, [true, false],
          default: true,
          description: 'Enable or disable mysql community server repo'
@@ -65,7 +69,7 @@ action :create do
     baseurl "https://repo.mysql.com/yum/mysql-#{new_resource.version}-community/#{os}/#{os_ver}/$basearch/"
     gpgcheck new_resource.gpgcheck
     enabled new_resource.mysql_community_server
-    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
+    gpgkey new_resource.gpgkey
   end
 
   yum_repository 'mysql-connectors-community' do
@@ -73,7 +77,7 @@ action :create do
     baseurl "https://repo.mysql.com/yum/mysql-connectors-community/#{os}/#{os_ver}/$basearch/"
     gpgcheck new_resource.gpgcheck
     enabled new_resource.mysql_connectors_community
-    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
+    gpgkey new_resource.gpgkey
   end
 
   yum_repository 'mysql-tools-community' do
@@ -81,7 +85,7 @@ action :create do
     baseurl "https://repo.mysql.com/yum/mysql-tools-community/#{os}/#{os_ver}/$basearch/"
     gpgcheck new_resource.gpgcheck
     enabled new_resource.mysql_tools_community
-    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
+    gpgkey new_resource.gpgkey
   end
 
   yum_repository 'mysql-tools-preview' do
@@ -89,7 +93,7 @@ action :create do
     baseurl "https://repo.mysql.com/yum/mysql-tools-preview/#{os}/#{os_ver}/$basearch/"
     gpgcheck new_resource.gpgcheck
     enabled new_resource.mysql_tools_preview
-    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
+    gpgkey new_resource.gpgkey
   end
 
   yum_repository 'mysql-cluster-community' do
@@ -97,7 +101,7 @@ action :create do
     baseurl "https://repo.mysql.com/yum/mysql-cluster-#{new_resource.version}-community/#{os}/#{os_ver}/$basearch/"
     gpgcheck new_resource.gpgcheck
     enabled new_resource.mysql_cluster_community
-    gpgkey 'https://repo.mysql.com/RPM-GPG-KEY-mysql-2022'
+    gpgkey new_resource.gpgkey
   end
 end
 


### PR DESCRIPTION
# Description

- Add gpgkey property to repo resource
- Default to 2023 GPG key

## Issues Resolved

Resolves #57 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
